### PR TITLE
Hard contacts

### DIFF
--- a/src/AG_numerical.cpp
+++ b/src/AG_numerical.cpp
@@ -235,6 +235,21 @@ namespace loos {
         return(sum);
   }
 
+  double AtomicGroup::hardContact(const AtomicGroup& group,
+                                      double radius,
+                                      const GCoord& box
+                                      ) const{
+        GCoord cent = centroid();
+        GCoord other = group.centroid();
+
+        double distance = cent.distance(other, box);
+        double sum = 0.;
+        if (distance <= radius) {
+            sum = 1.;
+        }
+        return(sum);
+  }
+
   greal AtomicGroup::radiusOfGyration(void) const {
     GCoord c = centerOfMass();
     greal radius = 0;

--- a/src/AG_numerical.cpp
+++ b/src/AG_numerical.cpp
@@ -235,6 +235,41 @@ namespace loos {
         return(sum);
   }
 
+  double AtomicGroup::logisticContact_2D(const AtomicGroup& group,
+                                      double radius,
+                                      int sigma,
+                                      const GCoord& box
+                                      ) const{
+        GCoord cent = centroid();
+        GCoord other = group.centroid();
+
+        cent.set(cent[0], cent[1], 0);
+        other.set(other[0], other[1], 0);
+
+        // Handle even and odd powers separately -- even can
+        // avoid the sqrt
+        // Sigh, this doesnt' seem to make it much faster...
+        double prod;
+        if (sigma % 2 == 0) {
+            double distance2 = cent.distance2(other, box);
+            double ratio = distance2/(radius*radius);
+            prod = ratio;
+            for (int j=0; j<(sigma/2)-1; ++j) {
+                prod *= ratio;
+            }
+        }
+        else {
+            double distance = cent.distance(other, box);
+            double ratio = distance/radius;
+            prod = ratio;
+            for (int j=0; j < sigma-1; ++j) {
+                prod *= ratio;
+            }
+        }
+        double sum = 1./(1. + prod);
+        return(sum);
+  }
+
   double AtomicGroup::hardContact(const AtomicGroup& group,
                                       double radius,
                                       const GCoord& box
@@ -242,14 +277,32 @@ namespace loos {
         GCoord cent = centroid();
         GCoord other = group.centroid();
 
-        double distance = cent.distance(other, box);
+        double distance2 = cent.distance2(other, box);
         double sum = 0.;
-        if (distance <= radius) {
+        if (distance2 <= (radius*radius)) {
             sum = 1.;
         }
         return(sum);
   }
 
+  double AtomicGroup::hardContact_2D(const AtomicGroup& group,
+                                      double radius,
+                                      const GCoord& box
+                                      ) const{
+        GCoord cent = centroid();
+        GCoord other = group.centroid();
+
+        cent.set(cent[0], cent[1], 0);
+        other.set(other[0], other[1], 0);
+
+        double distance2 = cent.distance2(other, box);
+        double sum = 0.;
+        if (distance2 <= (radius*radius)) {
+            sum = 1.;
+        }
+        return(sum);
+
+  }
   greal AtomicGroup::radiusOfGyration(void) const {
     GCoord c = centerOfMass();
     greal radius = 0;

--- a/src/AG_numerical.cpp
+++ b/src/AG_numerical.cpp
@@ -211,31 +211,11 @@ namespace loos {
         GCoord cent = centroid();
         GCoord other = group.centroid();
 
-        // Handle even and odd powers separately -- even can
-        // avoid the sqrt
-        // Sigh, this doesnt' seem to make it much faster...
-        double prod;
-        if (sigma % 2 == 0) {
-            double distance2 = cent.distance2(other, box);
-            double ratio = distance2/(radius*radius);
-            prod = ratio;
-            for (int j=0; j<(sigma/2)-1; ++j) {
-                prod *= ratio;
-            }
-        }
-        else {
-            double distance = cent.distance(other, box);
-            double ratio = distance/radius;
-            prod = ratio;
-            for (int j=0; j < sigma-1; ++j) {
-                prod *= ratio;
-            }
-        }
-        double sum = 1./(1. + prod);
+        double sum = logisticFunc(cent, other, radius, sigma, box);
         return(sum);
   }
 
-  double AtomicGroup::logisticContact_2D(const AtomicGroup& group,
+  double AtomicGroup::logisticContact2D(const AtomicGroup& group,
                                       double radius,
                                       int sigma,
                                       const GCoord& box
@@ -243,30 +223,10 @@ namespace loos {
         GCoord cent = centroid();
         GCoord other = group.centroid();
 
-        cent.set(cent[0], cent[1], 0);
-        other.set(other[0], other[1], 0);
+        cent.z() = 0.;
+        other.z() = 0.;
 
-        // Handle even and odd powers separately -- even can
-        // avoid the sqrt
-        // Sigh, this doesnt' seem to make it much faster...
-        double prod;
-        if (sigma % 2 == 0) {
-            double distance2 = cent.distance2(other, box);
-            double ratio = distance2/(radius*radius);
-            prod = ratio;
-            for (int j=0; j<(sigma/2)-1; ++j) {
-                prod *= ratio;
-            }
-        }
-        else {
-            double distance = cent.distance(other, box);
-            double ratio = distance/radius;
-            prod = ratio;
-            for (int j=0; j < sigma-1; ++j) {
-                prod *= ratio;
-            }
-        }
-        double sum = 1./(1. + prod);
+        double sum = logisticFunc(cent, other, radius, sigma, box);
         return(sum);
   }
 
@@ -285,15 +245,15 @@ namespace loos {
         return(sum);
   }
 
-  double AtomicGroup::hardContact_2D(const AtomicGroup& group,
+  double AtomicGroup::hardContact2D(const AtomicGroup& group,
                                       double radius,
                                       const GCoord& box
                                       ) const{
         GCoord cent = centroid();
         GCoord other = group.centroid();
 
-        cent.set(cent[0], cent[1], 0);
-        other.set(other[0], other[1], 0);
+        cent.z() = 0.;
+        other.z() = 0.;
 
         double distance2 = cent.distance2(other, box);
         double sum = 0.;

--- a/src/AtomicGroup.hpp
+++ b/src/AtomicGroup.hpp
@@ -803,6 +803,19 @@ namespace loos {
     double logisticContact(const AtomicGroup& group, double radius,
                            int sigma, const GCoord& box) const;
 
+    //* Similar to logisticContact() but the distance between reference
+    //  group centroid and another group centroid is 2D Euclidean distance
+    //  instead of 3D. Useful when calculating number of contacts in a 
+    //  plane
+    /**
+        Compute the number of contacts between the centroid of this AG
+        and the centroid of another AG, using a smooth logistic
+        function
+        S = 1/(1 + dist/radius)**sigma
+     */
+    double logisticContact_2D(const AtomicGroup& group, double radius,
+                           int sigma, const GCoord& box) const;
+
     //* Hard contact function between this group and another
     /**
         Compute contact value of another AG with respect to
@@ -811,6 +824,19 @@ namespace loos {
         S = 1; iff dist <= radius; else 0
      */
     double hardContact(const AtomicGroup& group, double radius,
+                           const GCoord& box) const;
+
+    //* Similar to hardContact() but the distance between reference
+    //  group centroid and another group centroid is 2D Euclidean distance
+    //  instead of 3D. Useful when calculating number of contacts or local
+    //  neighbor density in a plane
+    /**
+        Compute contact value of another AG with respect to
+        the centroid of a given AG, using a hard step
+        function
+        S = 1; iff dist <= radius; else 0
+     */
+    double hardContact_2D(const AtomicGroup& group, double radius,
                            const GCoord& box) const;
 
   private:

--- a/src/AtomicGroup.hpp
+++ b/src/AtomicGroup.hpp
@@ -813,7 +813,7 @@ namespace loos {
         function
         S = 1/(1 + dist/radius)**sigma
      */
-    double logisticContact_2D(const AtomicGroup& group, double radius,
+    double logisticContact2D(const AtomicGroup& group, double radius,
                            int sigma, const GCoord& box) const;
 
     //* Hard contact function between this group and another
@@ -836,7 +836,7 @@ namespace loos {
         function
         S = 1; iff dist <= radius; else 0
      */
-    double hardContact_2D(const AtomicGroup& group, double radius,
+    double hardContact2D(const AtomicGroup& group, double radius,
                            const GCoord& box) const;
 
   private:
@@ -861,6 +861,33 @@ namespace loos {
       GCoord _box;
     };
 
+
+    // This function is to to remove code duplication in 
+    // logisticContacts() and logisticContacts2D(). 
+    // Handle even and odd powers separately -- even can
+    // avoid the sqrt
+    // Sigh, this doesnt' seem to make it much faster...
+    double logisticFunc(const GCoord& cent, const GCoord& other, double radius, int sigma, const GCoord& box) const{
+        double prod;
+        if (sigma % 2 == 0) {
+            double distance2 = cent.distance2(other, box);
+            double ratio = distance2/(radius*radius);
+            prod = ratio;
+            for (int j=0; j<(sigma/2)-1; ++j) {
+                prod *= ratio;
+            }
+        }
+        else {
+            double distance = cent.distance(other, box);
+            double ratio = distance/radius;
+            prod = ratio;
+            for (int j=0; j < sigma-1; ++j) {
+                prod *= ratio;
+            }
+        }
+        double sum = 1./(1. + prod);
+        return(sum);
+    }
 
 
     // Find all atoms in the current group that are within dist

--- a/src/AtomicGroup.hpp
+++ b/src/AtomicGroup.hpp
@@ -803,6 +803,16 @@ namespace loos {
     double logisticContact(const AtomicGroup& group, double radius,
                            int sigma, const GCoord& box) const;
 
+    //* Hard contact function between this group and another
+    /**
+        Compute contact value of another AG with respect to
+        the centroid of a given AG, using a hard step
+        function
+        S = 1; iff dist <= radius; else 0
+     */
+    double hardContact(const AtomicGroup& group, double radius,
+                           const GCoord& box) const;
+
   private:
 
 	// These are functors for calculating distance between two coords


### PR DESCRIPTION
Added  two versions of hardContacts() function : One where the distance calculated between centroids is 3D Euclidean distance where for other it is 2D Euclidean distance. Useful if someone wants to find specific AG neighbors around a given AG selection within a cutoff radius. Also, useful if one wants to calculate local density of one AG around another within a cutoff radius.

Added 2D version of logisticContacts() earlier added by @agrossfield.