### PR TITLE
correctly export AtomicGroup.splitByName to python

### DIFF
--- a/src/AtomicGroup.i
+++ b/src/AtomicGroup.i
@@ -23,9 +23,12 @@
 %rename(cpp_splitByMolecule)       loos::AtomicGroup::splitByMolecule;
 %rename(cpp_splitByResidue)        loos::AtomicGroup::splitByResidue;
 %rename(cpp_splitByUniqueSegid)    loos::AtomicGroup::splitByUniqueSegid;
+%rename(cpp_splitByName)           loos::AtomicGroup::splitByName;
 
 
 %header %{
+
+#include <map>
 
 #include <AtomicGroup.hpp>
 #include <sfactories.hpp>
@@ -188,6 +191,12 @@ namespace loos {
               l.append(AtomicGroup(i))
           return(l)
 
+      def splitByName(self):
+          d = {}
+          v = self.cpp_splitByName()
+          for i in v.keys():
+              d[i] = AtomicGroup(v[i])
+          return d
 
 
 %}
@@ -203,3 +212,4 @@ namespace loos {
 
 
 %template(AtomicGroupVector) std::vector<loos::AtomicGroup>;
+%template(AtomicGroupMap)    std::map<std::string, loos::AtomicGroup>;

--- a/src/loos.i
+++ b/src/loos.i
@@ -10,6 +10,7 @@
 
 %include <std_string.i>
 %include <std_vector.i>
+%include <std_map.i>
 %include <boost_shared_ptr.i>
 
 


### PR DESCRIPTION
---
name: Pull request
about: Create a report to incorporate code
title: 'Set swig to correctly export AtomicGroup.splitByName'
labels: ''
assignees: ''
---

Fixes #68 

## Changes proposed in this pull request
    - Change loos.i and AtomicGroup.i
    - Set the return of AtomicGroup.splitByName() to be a python dictionary



## Checklist
    - Does this pull request address an open issue? If so, which one?
    - Have you applied a formatter to your code (e.g. flake8 or black for python, clang-format for C++)?
