### PR TITLE
Fix LoosOptions pre-made command line options

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2022-03-16 Alan Grossfield <alan>
+	* Fix LoosOptions issues so fullhelps work correctly in several PyLOOS
+	  tools (#71)
+	* Partially fixes #72, required arguments make a mess of things
+
 2021-11-22 Tod Romo <tromo>
 	* Merged branch RamaResidues, contributed by Louis Smith.  This adds
 	  a resid column to the output of ramachandran.
@@ -5,7 +10,7 @@
 2021-11-19 Alan Grossfield <alan>
 	* Merged new tool rare-event-detection.py, contributed
 	  by Grace Julien
-	  
+
 2021-11-12 Alan Grossfield <alan>
 	* Merge branch pdbelement, use atomic mass info to fill the
 	  element field when writing PDB files

--- a/Packages/PyLOOS/SConscript
+++ b/Packages/PyLOOS/SConscript
@@ -32,7 +32,7 @@ apps += 'simple_traj_calc axis_with_membrane inside_helices '
 apps += 'simple_traj_transform center_molecule native-hbs total_charge '
 apps += 'cluster-structures  packing_score_per_res cylindrical-density '
 apps += 'protein_tilt scattering all_stacking contact_distance '
-apps += 'sysinfo '
+apps += 'sysinfo rare-event-detection'
 
 # Moved libraries out of Packages/PyLOOS to loos/pyloos
 #files = 'ConvexHull NAMDBin'

--- a/Packages/PyLOOS/all_contacts.py
+++ b/Packages/PyLOOS/all_contacts.py
@@ -65,13 +65,14 @@ fullhelp = """
 
   """
 
-lo = options.LoosOptions(fullhelp)
+lo = options.LoosOptions("Compute probability of residue-residue contacts",
+                         fullhelp)
 lo.modelSelectionOptions()
 lo.trajOptions()
 
 
 lo.parser.add_argument('--out_file',
-                       required=True,
+                       default='outfile',
                        help="File with the average contact occupancies")
 lo.parser.add_argument('--cutoff', type=float,
                        help="Cutoff distance for contact", default=4.0)

--- a/Packages/PyLOOS/cylindrical-density.py
+++ b/Packages/PyLOOS/cylindrical-density.py
@@ -59,7 +59,8 @@ substantially changing the information content (the slash in front of the "!"
 may or may not be necessary, depending on which shell you use).
 """
 
-    lo = options.LoosOptions(fullhelp)
+    lo = options.LoosOptions("Compute 2D histogram in r,z about a selection",
+                             fullhelp)
 
     lo.modelSelectionOptions()
     lo.trajOptions()

--- a/Packages/PyLOOS/rare-event-detection.py
+++ b/Packages/PyLOOS/rare-event-detection.py
@@ -48,12 +48,13 @@ fullhelp = """
   https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.NMF.html
   Based on methodology outlined by Plante and Weinstein in
   https://doi.org/10.3390/molecules26103059
-  Window_length is the number of frames that will be averaged over before performing the NMF,
-  recommended to be approximately the number of frames per nanosecond.
-  It is recommended to play with n_components, using the expected number of
-  rare events in the trajectory based on the conformational changes required
-  for the molecular process as a starting point and experimenting with +/-
-  components until convergence is attained.
+  
+  Window_length is the number of frames that will be averaged over before
+  performing the NMF, recommended to be approximately the number of frames per
+  nanosecond.  It is recommended to play with n_components, using the expected
+  number of rare events in the trajectory based on the conformational changes
+  required for the molecular process as a starting point and experimenting with
+  +/- components until convergence is attained.
 
 
   Mandatory arguments:
@@ -95,7 +96,8 @@ def LowerTriIndex(row, col, n):
     return int(index)
 
 if __name__ == '__main__':
-    lo = options.LoosOptions(fullhelp)
+    lo = options.LoosOptions("Detect rare events in macromolecular trajectories",
+                             fullhelp)
     lo.modelSelectionOptions()
     lo.trajOptions()
 

--- a/loos/pyloos/options.py
+++ b/loos/pyloos/options.py
@@ -4,11 +4,25 @@ import argparse
 import sys
 
 
+class FullHelper(argparse.Action):
+    def __init__(self, option_strings, fullhelp, *args, **kwargs):
+        kwargs['nargs'] = 0
+        self._fullhelp = fullhelp
+        super(FullHelper, self).__init__(option_strings, *args, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        print(self._fullhelp)
+        parser.print_help()
+        setattr(namespace, self.dest, True)
+        parser.exit()
+
+
 class LoosOptions:
     """
         Parse command line options and implement common sets of options
         Implemented as a wrapper around argparse
     """
+
     def __init__(self, description, fullhelp=None):
         self.parser = argparse.ArgumentParser(description=description)
 
@@ -16,10 +30,9 @@ class LoosOptions:
             self.setFullhelp(fullhelp)
 
     def setFullhelp(self, fullhelp=None):
-        self.fullhelp = fullhelp
         self.parser.add_argument('--fullhelp',
-                                 action='store_true',
-                                 default=False)
+                                 action=FullHelper,
+                                 fullhelp=fullhelp)
 
     # Set up some default arguments
     def modelSelectionPositionalOptions(self):
@@ -30,17 +43,15 @@ class LoosOptions:
     # Set up some default arguments
     def modelSelectionOptions(self):
         self.parser.add_argument('-m', '--model',
-                                 help="Model file describing system contents",
-                                 required=True)
+                                 help="Model file describing system contents"
+                                 )
         self.parser.add_argument('--selection',
                                  help='Use this selection for computation',
-                                 required=True,
                                  default='all')
 
     def trajOptions(self):
         self.parser.add_argument('-t', '--traj',
                                  help='Filename of trajectory or trajectories',
-                                 required=True,
                                  nargs='+')
         self.parser.add_argument('-k', '--skip',
                                  help='Skip frames from the trajectory start',


### PR DESCRIPTION
---
name: Fix problems with the new LoosOptions module
about: Create a report to incorporate code
title: ''
labels: ''
assignees: ''
---

Fixes #71 and (partly) #72 

## Changes proposed in this pull request
    - Changes the way fullhelps are handled in LoosOptions (#71)
    - added descriptions to the tools that use LoosOptions (#71)
    - started getting rid of required options, since that breaks help and fullhelp (partially address #72)

