### PR TITLE
included switch to cast int64 to slice type for numpy compatibility

### DIFF
--- a/src/loos.i
+++ b/src/loos.i
@@ -6,6 +6,7 @@
 
 %{
 #define SWIG_FILE_WITH_INIT
+#define SWIG_PYTHON_CAST_MODE
 %}
 
 %include <std_string.i>


### PR DESCRIPTION
Fixes # .
fixes #80 

## Changes proposed in this pull request
    - Add `#define SWIG_PYTHON_CAST_MODE` switch to `loos.i` resolves issue (apparently). Fix is based on @tromo 's reading of [this swig issue](https://github.com/swig/swig/issues/888)
