### PR TITLE
make netcdf support mandatory, fix #91

### DIFF
--- a/src/OptionsFramework.cpp
+++ b/src/OptionsFramework.cpp
@@ -282,7 +282,7 @@ std::string TwoModelsWithCoords::print() const {
 void BasicTrajectory::addGeneric(po::options_description &opts) {
   std::string modeltypes = "Model types:\n" + availableSystemFileTypes();
   std::string trajtypes =
-      "Trajectory types:\n" + availableTrajectoryFileTypes();
+        "Trajectory types:\n" + availableTrajectoryFileTypes();
 
   opts.add_options()("skip,k",
                      po::value<unsigned int>(&skip)->default_value(skip),

--- a/src/loos.hpp
+++ b/src/loos.hpp
@@ -82,10 +82,7 @@
 #include <xtcwriter.hpp>
 
 #include <amber_traj.hpp>
-
-#if defined(HAS_NETCDF)
 #include <amber_netcdf.hpp>
-#endif
 
 #include <amber_rst.hpp>
 #include <ccpdb.hpp>

--- a/src/loos_defs.hpp
+++ b/src/loos_defs.hpp
@@ -132,9 +132,7 @@ namespace loos {
   class Trajectory;
   class DCD;
   class AmberTraj;
-#if defined(HAS_NETCDF)
   class AmberNetcdf;
-#endif
   class CCPDB;
   class TinkerArc;
   class PDBTraj;
@@ -146,9 +144,7 @@ namespace loos {
   typedef boost::shared_ptr<Trajectory> pTraj;
   typedef boost::shared_ptr<DCD> pDCD;
   typedef boost::shared_ptr<AmberTraj> pAmberTraj;
-#if defined(HAS_NETCDF)
   typedef boost::shared_ptr<AmberNetcdf> pAmberNetcdf;
-#endif
   typedef boost::shared_ptr<CCPDB> pCCPDB;
   typedef boost::shared_ptr<TinkerArc> pTinkerArc;
   typedef boost::shared_ptr<PDBTraj> pPDBTraj;

--- a/src/sfactories.cpp
+++ b/src/sfactories.cpp
@@ -37,10 +37,7 @@
 #include <dcd.hpp>
 #include <amber_traj.hpp>
 
-#if defined(HAS_NETCDF)
 #include <amber_netcdf.hpp>
-#endif
-
 #include <amber_rst.hpp>
 #include <ccpdb.hpp>
 #include <charmm.hpp>
@@ -129,15 +126,10 @@ namespace loos {
     };
 
     TrajectoryNameBindingType trajectory_name_bindings[] = {
-#if defined(HAS_NETCDF)
       { "crd", "Amber Traj (NetCDF/Amber)", &AmberNetcdf::create},
       { "mdcrd", "Amber Traj (NetCDF/Amber)", &AmberNetcdf::create},
       { "nc", "Amber Traj (NetCDF)", &AmberNetcdf::create},
       { "netcdf", "Amber Traj (NetCDF)", &AmberNetcdf::create},
-#else
-      { "crd", "Amber Traj", &AmberTraj::create},
-      { "mdcrd", "Amber Traj", &AmberTraj::create},
-#endif
       { "inpcrd", "Amber Restart", &AmberRst::create},
       { "rst", "Amber Restart", &AmberRst::create},
       { "rst7", "Amber Restart", &AmberRst::create},


### PR DESCRIPTION
---
name: Make netcdf support mandatory
about: 
title: 'make netcdf support mandatory, fix #91'
labels: ''
assignees: ''
---

Fixes #91  .

## Changes proposed in this pull request
    - Removed all instances of the HAS_NETCDF conditional compilation, since we always want to support it 


## Checklist
    - Does this pull request address an open issue? #91 
    - Have you applied a formatter to your code (e.g. flake8 or black for python, clang-format for C++)?
