### PR TITLE
added molecular order parameter to AtomicGroup

### DIFF
--- a/src/AG_numerical.cpp
+++ b/src/AG_numerical.cpp
@@ -459,6 +459,24 @@ namespace loos {
     }
   }
 
+
+  double AtomicGroup::principalAxesOrder(void) const {
+    const double minp = 1e-30;
+
+    std::vector<GCoord> axes = principalAxes();
+    // a planar molecule will only have 2 non-zero principle axes
+    bool planar = (abs(axes[3].z()) < minp);
+
+    double order = 0.5 - 1.5 * axes[1].z() * axes[1].z();
+    if (!planar) {
+      order += 0.5 - 1.5 * axes[2].z() * axes[2].z();
+      order *= 0.5;
+    }
+
+    return(order);
+  }
+
+
   greal AtomicGroup::stacking(const AtomicGroup& other,
                               const GCoord& box,
                               const double threshold=5.0) const {

--- a/src/AtomicGroup.hpp
+++ b/src/AtomicGroup.hpp
@@ -800,6 +800,23 @@ namespace loos
      */
     std::vector<GCoord> principalAxes(void) const;
 
+    //! Computes order parameter based on principalAxes
+    /**
+     * Computes the molecular order parameter by taking 2nd and 3rd
+     * principal axes and transforming using a 2nd order Legendre
+     * polynomial. This produces a whole-chain quantity with values 
+     * comparable to deuterium order parameters.
+     * 
+     * If the AtomicGroup is not planar, this returns the average of 
+     * the order parameter using the 2nd and 3rd axes. If the molecule is 
+     * planar, indicated by a near-zero 3rd moment, it simply returns the 2nd 
+     * moment's order parameter.
+     * 
+     * This implementation assumes you've already done any needed 
+     * transformations to the coordinates (eg reimaging by molecule)
+    */
+    double principalAxesOrder(void) const;
+
     //! Computes the moments of inertia for a group
     /**
      * Calculates the principal moments and principal axes (from the


### PR DESCRIPTION
---
name: add molecular order parameter to AtomicGroup
about: Create a report to incorporate code
title: 'add molecular order parameter to AtomicGroup'
labels: 'enhancement'
assignees: ''
---

## Changes proposed in this pull request
    - add new method to AtomicGroup so new tools can do molecular order parameter
    - reproduces results from `mops`
  



