### PR TITLE
Lbf fixup

### DIFF
--- a/Tools/long-bond-finder.cpp
+++ b/Tools/long-bond-finder.cpp
@@ -270,8 +270,8 @@ int main(int argc, char *argv[]) {
         dist2 = b[0]->coords().distance2(b[1]->coords());
         if (dist2 > max_bond2) {
           if (!topts->quiet)
-            cout << "Issue in "frame_index << "; bond between atomIDs " << b[0]->id() << " and " << b[1]->id() << 
-            " is overlong. Length is " << sqrtf(dist2) << ". Exiting..." endl;
+            cout << "Issue in frame " << frame_index << "; bond between atomIDs " << b[0]->id() << " and " << b[1]->id() << 
+            " is " << sqrtf(dist2) << " Angstroms. Exiting..." << endl;
           return EXIT_FAILURE;
         }
       }

--- a/Tools/long-bond-finder.cpp
+++ b/Tools/long-bond-finder.cpp
@@ -233,10 +233,12 @@ int main(int argc, char *argv[]) {
 
   // set up system for looping. Load coords from frame 0 into scope.
   AtomicGroup model = tropts->model;
-  if (model.hasBonds()) {
+  AtomicGroup scope = selectAtoms(model, sopts->selection);
+  bool all_bonds_in_scope = scope.allHaveProperty(Atom::bits::bondsbit);
+  if (all_bonds_in_scope) {
   } else if (topts->bondlength > 0)
-    if (model.hasCoords())
-      model.findBonds(topts->bondlength);
+    if (scope.hasCoords())
+      scope.findBonds(topts->bondlength);
     else {
       throw(LOOSError(
         "Model does not have coordinates with which to infer connectivity.\n"
@@ -244,9 +246,8 @@ int main(int argc, char *argv[]) {
     }
   else
     throw(LOOSError(
-        "Model does not appear to have chemical connectivity, and "
+        "Model selection does not appear to have chemical connectivity, and "
         "infer-connectivity has not been set to a positive value.\n"));
-  AtomicGroup scope = selectAtoms(model, sopts->selection);
   pTraj traj = tropts->trajectory;
   traj->updateGroupCoords(model);
   // should be a vector of two-atom AGs, each a pair of atoms in a bond
@@ -260,11 +261,17 @@ int main(int argc, char *argv[]) {
     // if thrown, don't even write invocation to stdout
     if (!topts->quiet)
       cout << "# " << header << "\n";
+    
+    float dist2 = 0;
     for (auto frame_index : tropts->frameList()) {
       traj->readFrame(frame_index);
       traj->updateGroupCoords(scope);
       for (auto b : bond_list) {
-        if (b[0]->coords().distance2(b[1]->coords()) > max_bond2) {
+        dist2 = b[0]->coords().distance2(b[1]->coords());
+        if (dist2 > max_bond2) {
+          if (!topts->quiet)
+            cout << "Issue in "frame_index << "; bond between atomIDs " << b[0]->id() << " and " << b[1]->id() << 
+            " is overlong. Length is " << sqrtf(dist2) << ". Exiting..." endl;
           return EXIT_FAILURE;
         }
       }


### PR DESCRIPTION
---
name: Pull request
about: Create a report to incorporate code
title: 'long-bond-finder fixup'
labels: 'C++ Tools'
assignees: 'Alan'
---

Fixes # .

## Changes proposed in this pull request
    - Changed the way connectivity is checked for (just within a selection now). This fixes an annoying surprise when dealing with .gro files (because they lack connectivity and you don't want to have to infer it across an entire model using only one cutoff). 
    - Made the tool print the frame and offending bond it finds if `--quiet` isn't thrown and `--time-series` isn't provided. This will be the default behavior of the tool if no options are specified now. The return values of the tool will not change.


## Checklist
    - Does this pull request address an open issue? If so, which one? No, I noticed the problem and fixed it in my own usage.
    - Have you applied a formatter to your code (e.g. flake8 or black for python, clang-format for C++)? No, I had applied a formatter previously and believe that my code is still formatted correctly because changes were small.
