### PR TITLE
Lbf fixup

### DIFF
--- a/Tools/long-bond-finder.cpp
+++ b/Tools/long-bond-finder.cpp
@@ -270,8 +270,8 @@ int main(int argc, char *argv[]) {
         dist2 = b[0]->coords().distance2(b[1]->coords());
         if (dist2 > max_bond2) {
           if (!topts->quiet)
-            cout << "Issue in "frame_index << "; bond between atomIDs " << b[0]->id() << " and " << b[1]->id() << 
-            " is overlong. Length is " << sqrtf(dist2) << ". Exiting..." endl;
+            cout << "Issue in frame " << frame_index << "; bond between atomIDs " << b[0]->id() << " and " << b[1]->id() << 
+            " is " << sqrtf(dist2) << " Angstroms. Exiting..." << endl;
           return EXIT_FAILURE;
         }
       }

--- a/Tools/long-bond-finder.cpp
+++ b/Tools/long-bond-finder.cpp
@@ -216,7 +216,8 @@ public:
 // @endcond
 // ----------------------------------------------------------------
 
-int main(int argc, char *argv[]) {
+int main(int argc, char *argv[])
+{
 
   string header = invocationHeader(argc, argv);
   opts::BasicOptions *bopts = new opts::BasicOptions(msg);
@@ -235,14 +236,15 @@ int main(int argc, char *argv[]) {
   AtomicGroup model = tropts->model;
   AtomicGroup scope = selectAtoms(model, sopts->selection);
   bool all_bonds_in_scope = scope.allHaveProperty(Atom::bits::bondsbit);
-  if (all_bonds_in_scope) {
-  } else if (topts->bondlength > 0)
+  if (all_bonds_in_scope)
+    scope.pruneBonds();
+  else if (topts->bondlength > 0)
     if (scope.hasCoords())
       scope.findBonds(topts->bondlength);
-    else {
+    else
+    {
       throw(LOOSError(
-        "Model does not have coordinates with which to infer connectivity.\n"
-      ));
+          "Model does not have coordinates with which to infer connectivity.\n"));
     }
   else
     throw(LOOSError(
@@ -257,41 +259,49 @@ int main(int argc, char *argv[]) {
 
   // Operating in scanning mode;
   // don't report anything except the presence of an unacceptable bond
-  if (topts->timeseries.empty()) {
+  if (topts->timeseries.empty())
+  {
     // if thrown, don't even write invocation to stdout
     if (!topts->quiet)
       cout << "# " << header << "\n";
-    
+
     float dist2 = 0;
-    for (auto frame_index : tropts->frameList()) {
+    for (auto frame_index : tropts->frameList())
+    {
       traj->readFrame(frame_index);
       traj->updateGroupCoords(scope);
-      for (auto b : bond_list) {
+      for (auto b : bond_list)
+      {
         dist2 = b[0]->coords().distance2(b[1]->coords());
-        if (dist2 > max_bond2) {
+        if (dist2 > max_bond2)
+        {
           if (!topts->quiet)
-            cout << "Issue in frame " << frame_index << "; bond between atomIDs " << b[0]->id() << " and " << b[1]->id() << 
-            " is " << sqrtf(dist2) << " Angstroms. Exiting..." << endl;
+            cout << "Issue in frame " << frame_index << "; bond between atomIDs " << b[0]->id() << " and " << b[1]->id() << " is " << sqrtf(dist2) << " Angstroms. Exiting..." << endl;
           return EXIT_FAILURE;
         }
       }
     }
-  } else { 
+  }
+  else
+  {
     // Operating in timeseries mode;
     // write a timeseries to file name provided by user
     ofstream tsf(topts->timeseries);
     bool found_viol = false;
     tsf << "# " << header << "\n"
         << "# frame atomID1 atomID2 bondlength\n";
-    for (auto frame_index : tropts->frameList()) {
+    for (auto frame_index : tropts->frameList())
+    {
       traj->readFrame(frame_index);
       traj->updateGroupCoords(scope);
       float dist2 = 0;
-      for (auto b : bond_list) {
+      for (auto b : bond_list)
+      {
         dist2 = b[0]->coords().distance2(b[1]->coords());
-        if (dist2 > max_bond2) {
+        if (dist2 > max_bond2)
+        {
           found_viol = true;
-          tsf << frame_index << " " << b[0]->id() << " " << b[1]->id() 
+          tsf << frame_index << " " << b[0]->id() << " " << b[1]->id()
               << " " << sqrtf(dist2) << "\n";
         }
       }

--- a/Tools/long-bond-finder.cpp
+++ b/Tools/long-bond-finder.cpp
@@ -233,10 +233,12 @@ int main(int argc, char *argv[]) {
 
   // set up system for looping. Load coords from frame 0 into scope.
   AtomicGroup model = tropts->model;
-  if (model.hasBonds()) {
+  AtomicGroup scope = selectAtoms(model, sopts->selection);
+  bool all_bonds_in_scope = scope.allHaveProperty(Atom::bits::bondsbit);
+  if (all_bonds_in_scope) {
   } else if (topts->bondlength > 0)
-    if (model.hasCoords())
-      model.findBonds(topts->bondlength);
+    if (scope.hasCoords())
+      scope.findBonds(topts->bondlength);
     else {
       throw(LOOSError(
         "Model does not have coordinates with which to infer connectivity.\n"
@@ -244,9 +246,8 @@ int main(int argc, char *argv[]) {
     }
   else
     throw(LOOSError(
-        "Model does not appear to have chemical connectivity, and "
+        "Model selection does not appear to have chemical connectivity, and "
         "infer-connectivity has not been set to a positive value.\n"));
-  AtomicGroup scope = selectAtoms(model, sopts->selection);
   pTraj traj = tropts->trajectory;
   traj->updateGroupCoords(model);
   // should be a vector of two-atom AGs, each a pair of atoms in a bond
@@ -260,11 +261,17 @@ int main(int argc, char *argv[]) {
     // if thrown, don't even write invocation to stdout
     if (!topts->quiet)
       cout << "# " << header << "\n";
+    
+    float dist2 = 0;
     for (auto frame_index : tropts->frameList()) {
       traj->readFrame(frame_index);
       traj->updateGroupCoords(scope);
       for (auto b : bond_list) {
-        if (b[0]->coords().distance2(b[1]->coords()) > max_bond2) {
+        dist2 = b[0]->coords().distance2(b[1]->coords());
+        if (dist2 > max_bond2) {
+          if (!topts->quiet)
+            cout << "Issue in "frame_index << "; bond between atomIDs " << b[0]->id() << " and " << b[1]->id() << 
+            " is overlong. Length is " << sqrtf(dist2) << ". Exiting..." endl;
           return EXIT_FAILURE;
         }
       }

--- a/Tools/long-bond-finder.cpp
+++ b/Tools/long-bond-finder.cpp
@@ -236,20 +236,20 @@ int main(int argc, char *argv[])
   AtomicGroup model = tropts->model;
   AtomicGroup scope = selectAtoms(model, sopts->selection);
   bool all_bonds_in_scope = scope.allHaveProperty(Atom::bits::bondsbit);
-  if (all_bonds_in_scope)
+  if (all_bonds_in_scope) {
     scope.pruneBonds();
-  else if (topts->bondlength > 0)
+  } else if (topts->bondlength > 0)
     if (scope.hasCoords())
       scope.findBonds(topts->bondlength);
-    else
-    {
+    else {
       throw(LOOSError(
           "Model does not have coordinates with which to infer connectivity.\n"));
     }
-  else
+  else {
     throw(LOOSError(
         "Model selection does not appear to have chemical connectivity, and "
         "infer-connectivity has not been set to a positive value.\n"));
+  }
   pTraj traj = tropts->trajectory;
   traj->updateGroupCoords(model);
   // should be a vector of two-atom AGs, each a pair of atoms in a bond


### PR DESCRIPTION
---
name: lbf fixup
about: fixes subsetting in prebuilt tool `long-bond-finder`
title: 'Long bond finder subset fix'
labels: 'bug-fix'
assignees: ''
---
# Found a small but critical error in long-bond finder that makes its subsetting selection fail--it didn't call prune-bonds after subsetting.

## Changes proposed in this pull request
    - added call to prune bonds for scope if scope has bonds.
        - If model doesn't have all bonds, this test is skipped.


## Checklist
    - no open issue is addressed.
    - Have you applied a formatter to your code (e.g. flake8 or black for python, clang-format for C++)? Yes.
