### PR TITLE
index and id were swapped in translation from GEMMI API.

### DIFF
--- a/src/mmcif.cpp
+++ b/src/mmcif.cpp
@@ -51,8 +51,8 @@ namespace loos {
                 std::string res_entity_id = residue.entity_id;
                 for (auto atom:residue.atoms) {
                     loos::pAtom pa(new loos::Atom);
-                    pa->index(atom.serial);
-                    pa->id(atom_index);
+                    pa->index(atom_index);
+                    pa->id(atom.serial);  // from gemmi, comes from _atom_site.id in CIF records.
                     pa->name(atom.name);
                     pa->PDBelement(atom.element.name());
                     pa->coords().x(atom.pos.x);


### PR DESCRIPTION
---
name: fix CIF parsing from GEMMI api
about: Very simple issue; the meaning of `atom_index` and `atom.serial` was swapped from the GEMMI to loos.
title: 'fix-cif'
labels: 'bug'
assignees: ''
---

Fixes #  CIF reading

## Changes proposed in this pull request

Bind `atom_index` to `pAtom->index` and `atom.serial` to `pAtom->id` in creating an AG from a [GEMMI mmcif atom](https://gemmi.readthedocs.io/en/stable/mol.html#atom).