### PR TITLE
Pyloos subset

### DIFF
--- a/loos/src/loos/pyloos/trajectories.py
+++ b/loos/src/loos/pyloos/trajectories.py
@@ -77,6 +77,7 @@ class Trajectory(object):
         self._stride = 1
         self._iterator = None
         self._update_full = kwargs.get('update_full', True)
+        self._suppress_update_full_warning = kwargs.get('suppress_update_full_warning', False)
 
         if 'skip' in kwargs:
             self._skip = kwargs['skip']
@@ -97,11 +98,12 @@ class Trajectory(object):
             self._target = self._model
         else:
             self._target = self._subset
-            sys.stderr.write(
-                "Warning- pyloos.Trajectory: update_full=False means the model "
-                "you instantiated the trajectory object with will go stale; "
-                "use traj_object.refreshModel() to update it explicitly.\n"
-            )
+            if not self._suppress_update_full_warning:
+                sys.stderr.write(
+                    "Warning- pyloos.Trajectory: update_full=False means the model "
+                    "you instantiated the trajectory object with will go stale; "
+                    "use traj_object.refreshModel() to update it explicitly.\n"
+                )
 
         self._model_dirty = False
         self._stale = 1

--- a/loos/src/loos/pyloos/trajectories.py
+++ b/loos/src/loos/pyloos/trajectories.py
@@ -11,12 +11,13 @@ import copy
 # a loos::Trajectory.  The behavior of the trajectory can be controlled
 # through passed keywords,
 #
-# Keyword    | Description
-# -----------|------------------------------------------------------------------------------
-# skip=n     | Skip the first n-frames of the wrapped trajectory
-# stride=n   | Step through the wrapped trajectory n-frames at a time
-# iterator=i | Use the python iterator object i to select frames from the wrapped trajectory
-# subset=s   | Use 's' to select a subset of the model to use for each frame
+# Keyword       | Description
+# --------------|------------------------------------------------------------------------------
+# skip=n        | Skip the first n-frames of the wrapped trajectory
+# stride=n      | Step through the wrapped trajectory n-frames at a time
+# iterator=i    | Use the python iterator object i to select frames from the wrapped trajectory
+# subset=s      | Use 's' to select a subset of the model to use for each frame
+# update_full=b | If False, only update coords for the subset each frame (faster, but other selections from the model won't see updates).  Default True.
 #
 # Remember that all atoms are shared.  If you want to decouple the
 # trajectory from other groups, pass it a copy of the model.
@@ -59,10 +60,11 @@ class Trajectory(object):
     >>> traj = loos.pyloos.Trajectory('foo.dcd', model)
 
     keyword args:
-        skip = # of frames to skip from start
-      stride = # of frames to step through
-    iterator = Python iterator used to pick frame (overrides skip and stride)
-      subset = Selection used to pick subset for each frame
+         skip = # of frames to skip from start
+       stride = # of frames to step through
+     iterator = Python iterator used to pick frame (overrides skip and stride)
+       subset = Selection used to pick subset for each frame
+  update_full = If False, only update subset coords each frame (default True)
 
     See the Doxygen documentation for more details.
     """
@@ -73,6 +75,7 @@ class Trajectory(object):
         self._skip = 0
         self._stride = 1
         self._iterator = None
+        self._update_full = kwargs.get('update_full', True)
 
         if 'skip' in kwargs:
             self._skip = kwargs['skip']
@@ -88,6 +91,11 @@ class Trajectory(object):
         self._model = model
         self._fname = fname
         self._traj = loos.createTrajectory(fname, model)
+
+        if self._update_full:
+            self._target = self._model
+        else:
+            self._target = self._subset
 
         self._stale = 1
         self._initFrameList()
@@ -130,6 +138,8 @@ class Trajectory(object):
         The selection is a LOOS selection string.
         """
         self._subset = loos.selectAtoms(self._model, selection)
+        if not self._update_full:
+            self._target = self._subset
 
 
     def __iter__(self):
@@ -182,7 +192,7 @@ class Trajectory(object):
         if (i < 0 or i >= len(self._framelist)):
             raise IndexError
         self._traj.readFrame(self._framelist[i])
-        self._traj.updateGroupCoords(self._model)
+        self._traj.updateGroupCoords(self._target)
         return(self._subset)
 
     def frame(self):
@@ -232,7 +242,7 @@ class Trajectory(object):
         ensemble = []
         for i in indices:
             self._traj.readFrame(self._framelist[i])
-            self._traj.updateGroupCoords(self._model)
+            self._traj.updateGroupCoords(self._target)
             dup = self._subset.copy()
             ensemble.append(dup)
         return(ensemble)
@@ -251,7 +261,7 @@ class Trajectory(object):
         if (i >= len(self._framelist) or i < 0):
             raise IndexError
         self._traj.readFrame(self._framelist[i])
-        self._traj.updateGroupCoords(self._model)
+        self._traj.updateGroupCoords(self._target)
         return(self._subset)
 
 

--- a/loos/src/loos/pyloos/trajectories.py
+++ b/loos/src/loos/pyloos/trajectories.py
@@ -2,6 +2,7 @@
 Python-based trajectory classes that wrap loos.Trajectory objects
 
 """
+import sys
 import loos
 import copy
 
@@ -96,7 +97,13 @@ class Trajectory(object):
             self._target = self._model
         else:
             self._target = self._subset
+            sys.stderr.write(
+                "Warning- pyloos.Trajectory: update_full=False means the model "
+                "you instantiated the trajectory object with will go stale; "
+                "use traj_object.refreshModel() to update it explicitly.\n"
+            )
 
+        self._model_dirty = False
         self._stale = 1
         self._initFrameList()
 
@@ -193,7 +200,22 @@ class Trajectory(object):
             raise IndexError
         self._traj.readFrame(self._framelist[i])
         self._traj.updateGroupCoords(self._target)
+        if not self._update_full:
+            self._model_dirty = True
         return(self._subset)
+
+
+    def refreshModel(self):
+        """
+        Update the full model's coordinates from the trajectory's current frame.
+        Only relevant in update_full=False mode, where the per-frame update
+        touches only the subset.  No-op if the model is already current.
+        Returns the model AtomicGroup.
+        """
+        if self._model_dirty:
+            self._traj.updateGroupCoords(self._model)
+            self._model_dirty = False
+        return(self._model)
 
     def frame(self):
         """Return the current frame (subset)"""
@@ -245,6 +267,8 @@ class Trajectory(object):
             self._traj.updateGroupCoords(self._target)
             dup = self._subset.copy()
             ensemble.append(dup)
+        if not self._update_full and indices:
+            self._model_dirty = True
         return(ensemble)
 
 
@@ -262,6 +286,8 @@ class Trajectory(object):
             raise IndexError
         self._traj.readFrame(self._framelist[i])
         self._traj.updateGroupCoords(self._target)
+        if not self._update_full:
+            self._model_dirty = True
         return(self._subset)
 
 


### PR DESCRIPTION
---
name: Pyloos Subset
about: adding an optional subset functionality that deploys update group coords on the subset kwarg AtomicGroup.
title: 'Pyloos Subset'
labels: 'feature'
assignees: ''
---

## Changes proposed in this pull request
- Within the `PyLOOS.Trajectory` object, set `full_update=False` to set the `self._target` atomic group to the `self._subset` atomic group already defined. Otherwise `_model` is bound to target. 
- `updateGroupCoords` is always applied to `self._target`
- Emit a warning about how this will leave whatever group you used for 'model' to instantiate the traj as stale.
- define a method `refreshModel()` that calls updateGroupCoords on the `self._model` AG instead. 
   - This allows users to do a 'two step' analysis, if they want.

## Comment
This was done to enhance performance on reading subsets of trajectories where the difference in atom counts beween the full frame and the subset is really significant. For example, when analyzing a protein in a large water box, the fraction of C$`\alpha`$s to all atoms might be 0.2\%. At that kind of ratio, I was seeing a 4.4x speedup from using this subsetting for just reading through the coordinates I wanted.
