### PR TITLE
Conda build fixes

### DIFF
--- a/conda_build.sh
+++ b/conda_build.sh
@@ -119,8 +119,9 @@ echo "*** Configuring LOOS ***"
 cmake -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} ..
 
 echo "*** Building LOOS ***"
-if ! cmake --build . -j${numprocs} ; then
-    echo "*** LOOS build failed; skipping install ***"
+set -o pipefail
+if ! cmake --build . -j${numprocs} 2>&1 | tee build.log ; then
+    echo "*** LOOS build failed; full output in build/build.log ***"
     exit 1
 fi
 

--- a/conda_build.sh
+++ b/conda_build.sh
@@ -108,7 +108,8 @@ source $CONDA_BASE/etc/profile.d/conda.sh
 conda activate $envname
 
 if [[ -d build ]] ; then
-    echo "Warning- using existing build directory"
+    echo "Warning- using existing build directory; clearing CMakeCache.txt to force a fresh configure against $CONDA_PREFIX"
+    rm -f build/CMakeCache.txt
 else
     mkdir build
 fi
@@ -118,7 +119,10 @@ echo "*** Configuring LOOS ***"
 cmake -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} ..
 
 echo "*** Building LOOS ***"
-cmake --build . -j${numprocs}
+if ! cmake --build . -j${numprocs} ; then
+    echo "*** LOOS build failed; skipping install ***"
+    exit 1
+fi
 
 if [[ ${do_install} ]]; then
     echo  "*** Installing LOOS ***"


### PR DESCRIPTION
---
name: conda-build-fixes
about: Ran into small issue when working with pyloos, where two different odd interactions meant my rerunning of the script installed a stale version of pyloos into my mamba env, even though that's what I was wrenching on. These fixes would have prevented me from having this issue.
title: Stale pyloos cache, and silent failure.
labels: build
assignees: ''
---

Didn't make an issue, just proposing this fix.

## Changes proposed in this pull request
- Check for 'build' based cmake build. If so, instead of emitting a warning just clear the CMakeCache.txt so that it gets built afresh.
- If the build fails, emit a warning and stop there. 
- Tee the output from the build into a logfile, to make it easier for multithreaded builds not to blow the error msg offscreen.